### PR TITLE
fix: 修复连续搜索时结果不刷新

### DIFF
--- a/web/src/AppDesktop.vue
+++ b/web/src/AppDesktop.vue
@@ -102,7 +102,7 @@
     <div
       id="router-view-container" tabindex="-1"
       :style="{ 'width': '100%', 'max-width': '100%', 'margin-top': routerMarginTop, background: '#ffffff', 'margin-bottom': '10px', 'flex': 1, 'min-height': 0, 'overflow-y': 'auto', 'overflow-x': 'hidden', position: 'relative' }">
-      <router-view id="router-view" :key="`${String($route.name)}:${JSON.stringify($route.params)}`" class="router-view" @alert="alert" @set_loading="setLoading"
+      <router-view id="router-view" :key="routeViewKey" class="router-view" @alert="alert" @set_loading="setLoading"
         @search_type_changed="handleSearchTypeChanged" />
     </div>
   </v-app>
@@ -137,7 +137,7 @@ export default {
     const ifMobile = { value: false };
     
     // 路由状态
-    const { page, ifAvatarState } = useRouteState();
+    const { page, ifAvatarState, routeViewKey } = useRouteState();
     // 用户信息
     const { userId, userName } = useUser();
     
@@ -271,6 +271,7 @@ export default {
       // 路由
       page,
       ifAvatarState,
+      routeViewKey,
       // 用户
       userId,
       userName,

--- a/web/src/AppDesktop.vue
+++ b/web/src/AppDesktop.vue
@@ -17,7 +17,8 @@
       <v-spacer v-if="ifPCShowIndexTypeTab"></v-spacer>
       <search-input id="search-box-listen" v-model="searchContent" :borderColor="navIconColor"
         :boxShadowColor="hexToRgba(navIconColor, 0.5)" :placeholderColor="navIconColor"
-        :inputStyle="{ 'border-radius': '20px', height: '35px',width: ifPCShowIndexTypeTab ? '260px' : '500px', 'padding-left': '15px' }"></search-input>
+        :inputStyle="{ 'border-radius': '20px', height: '35px',width: ifPCShowIndexTypeTab ? '260px' : '500px', 'padding-left': '15px' }"
+        @submit="search"></search-input>
       <div class="search-btn-container">
         <v-btn id="search-btn" aria-label="搜索" @click="search" icon="mdi-magnify" variant="text" :color="navIconColor" size="35">
           <div class="icon-container">
@@ -332,24 +333,6 @@ export default {
   },
   mounted() {
     this.setLoadState(true);
-    
-    // 搜索框回车事件监听
-    try {
-      let searchBox = document.getElementById('search-box-listen');
-      if (searchBox) {
-        searchBox.addEventListener('keydown', function (event) {
-          if (event.key === 'Enter' || event.keyCode == 13) {
-            event.preventDefault();
-            const searchBtn = document.getElementById('search-btn');
-            if (searchBtn) {
-              searchBtn.click();
-            }
-          }
-        });
-      }
-    } catch (e) {
-      // 忽略错误
-    }
     
     // 监听搜索输入事件总线
     this.searchInputEventBus.on("fill-search-input", (value) => {

--- a/web/src/AppMobile.vue
+++ b/web/src/AppMobile.vue
@@ -88,7 +88,7 @@
     <div
       id="router-view-container" tabindex="-1"
       :style="{ 'width': '100vw', 'max-width': '100vw', 'margin-top': routerMarginTop, background: '#ffffff', 'margin-bottom': routerMarginBottom, 'flex': 1, 'min-height': 0, 'overflow-y': 'auto', position: 'relative' }">
-      <router-view id="router-view" :key="`${String($route.name)}:${JSON.stringify($route.params)}`" class="router-view" @alert="alert" @set_loading="setLoading"
+      <router-view id="router-view" :key="routeViewKey" class="router-view" @alert="alert" @set_loading="setLoading"
         @search_type_changed="handleSearchTypeChanged" />
     </div>
     <nav v-if="ifShowBottomNav" class="bottom-nav-container" aria-label="主导航">
@@ -174,7 +174,7 @@ export default {
     const showSplash = ref(false);
     
     // 路由状态
-    const { page, ifAvatarState } = useRouteState();
+    const { page, ifAvatarState, routeViewKey } = useRouteState();
     
     // 特殊页面状态（与帖子/文章等一致：显示 返回+首页+搜索+更多 的导航栏）
     const isSpecialPage = computed(() => {
@@ -380,6 +380,7 @@ export default {
       // 路由
       page,
       ifAvatarState,
+      routeViewKey,
       // 特殊页面
       isSpecialPage,
       showSpecialSearchInput,

--- a/web/src/AppMobile.vue
+++ b/web/src/AppMobile.vue
@@ -27,6 +27,7 @@
         :borderColor="navIconColor" :can-suggestion="ifCanSearchInputSuggestion"
         :boxShadowColor="hexToRgba(navIconColor, 0.5)" :placeholderColor="navIconColor"
         @blur="handleSpecialSearchBlur"
+        @submit="handleSpecialSearchClick"
         :inputStyle="{ 'font-color': navIconColor, 'border-radius': '20px', height: '35px', width: '60vw', 'padding-left': '15px' }"></search-input>
       <!-- 搜索按钮 -->
       <div class="nav-btn-container">
@@ -61,6 +62,7 @@
         :borderColor="navIconColor" :can-suggestion="ifCanSearchInputSuggestion"
         :boxShadowColor="hexToRgba(navIconColor, 0.5)" :placeholderColor="navIconColor"
         @blur="handleDetailPageSearchBlur"
+        @submit="search"
         :inputStyle="{ 'font-color': navIconColor, 'border-radius': '20px', height: '35px', width: '60vw', 'padding-left': '15px' }"></search-input>
       <div v-show="mobileIfShowSearchInput" class="search-btn-container">
         <v-btn id="search-btn" aria-label="搜索" @click="search" icon="mdi-magnify" variant="text" :color="navIconColor" size="35">
@@ -456,52 +458,6 @@ export default {
   },
   mounted() {
     this.setLoadState(true);
-    
-    // 搜索框回车事件监听
-    try {
-      let searchBox = document.getElementById('search-box-listen');
-      if (searchBox) {
-        searchBox.addEventListener('keydown', function (event) {
-          if (event.key === 'Enter' || event.keyCode == 13) {
-            event.preventDefault();
-            const searchBtn = document.getElementById('search-btn');
-            if (searchBtn) {
-              searchBtn.click();
-            }
-          }
-        });
-      }
-      
-      // 特殊页面搜索框事件监听（延迟执行，确保 DOM 已渲染）
-      this.$nextTick(() => {
-        let specialSearchBox = document.getElementById('search-box-listen-special');
-        if (specialSearchBox) {
-          const input = specialSearchBox.querySelector('input');
-          if (input) {
-            // 监听回车键事件
-            input.addEventListener('keydown', (event) => {
-              if (event.key === 'Enter' || event.keyCode == 13) {
-                event.preventDefault();
-                // 执行搜索并隐藏搜索框
-                this.search();
-                this.showSpecialSearchInput = false;
-              }
-            });
-            // 监听失去焦点事件
-            input.addEventListener('blur', () => {
-              // 延迟隐藏，以便点击其他按钮时不会立即隐藏
-              setTimeout(() => {
-                if (this.showSpecialSearchInput) {
-                  this.showSpecialSearchInput = false;
-                }
-              }, 200);
-            });
-          }
-        }
-      });
-    } catch (e) {
-      // 忽略错误
-    }
     
     // 监听搜索输入事件总线
     this.searchInputEventBus.on("fill-search-input", (value) => {

--- a/web/src/app/composables/useRouteState.js
+++ b/web/src/app/composables/useRouteState.js
@@ -1,13 +1,26 @@
 /**
  * 路由状态管理 Composable
  */
-import { ref, watch, nextTick } from 'vue';
+import { ref, watch, nextTick, computed } from 'vue';
 import { useRoute } from 'vue-router';
+
+export function getRouteViewKey(route) {
+  const routeName = String(route.name || '');
+  const baseKey = `${routeName}:${JSON.stringify(route.params || {})}`;
+  const pageName = routeName.replace(/Debug$/, '');
+
+  if (pageName === 'SearchPage') {
+    return `${baseKey}:${route.fullPath}`;
+  }
+
+  return baseKey;
+}
 
 export function useRouteState() {
   const route = useRoute();
   const page = ref('');
   const ifAvatarState = ref(true);
+  const routeViewKey = computed(() => getRouteViewKey(route));
   
   // 监听路由变化 - 使用 fullPath 确保路由参数变化时也能触发
   // fullPath 包含了路径和查询参数，任何路由变化都会触发
@@ -28,6 +41,6 @@ export function useRouteState() {
   return {
     page,
     ifAvatarState,
+    routeViewKey,
   };
 }
-

--- a/web/src/components/common/searchInput/SearchInput.vue
+++ b/web/src/components/common/searchInput/SearchInput.vue
@@ -8,6 +8,7 @@
       @focus="onFocus"
       @blur="onBlur"
       @input="onInput"
+      @keydown.enter.prevent="submitSearch"
       :placeholder="placeholderText"
     />
     <div
@@ -30,6 +31,7 @@ import { getLock, setLock } from '@/utils/lock';
 import RecommendCard from './utils/RecommendCard.vue';
 
 export default {
+  emits: ['update:modelValue', 'blur', 'submit'],
   setup() {
     let eventBus = createEventBus("search-suggestion-show");
     return {
@@ -124,6 +126,9 @@ export default {
     },
     onInput() {
       // 在这里监听当前输入的内容
+    },
+    submitSearch() {
+      this.$emit('submit');
     },
     fillSearchInput(text){
       this.inputValue=text;

--- a/web/tests/unit/components/SearchInput.spec.js
+++ b/web/tests/unit/components/SearchInput.spec.js
@@ -1,0 +1,58 @@
+import { mount } from '@vue/test-utils';
+import SearchInput from '@/components/common/searchInput/SearchInput.vue';
+
+jest.mock('@/components/common/searchInput/utils/HistoryCard.vue', () => ({
+  name: 'HistoryCard',
+  template: '<div />',
+}));
+
+jest.mock('@/components/common/searchInput/utils/RecommendCard.vue', () => ({
+  name: 'RecommendCard',
+  template: '<div />',
+}));
+
+describe('SearchInput', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
+  });
+
+  test('按 Enter 时只提交一次搜索', async () => {
+    const wrapper = mount(SearchInput, {
+      props: {
+        modelValue: '测试内容',
+      },
+      global: {
+        stubs: {
+          HistoryCard: true,
+          RecommendCard: true,
+        },
+      },
+    });
+
+    await wrapper.find('input').trigger('keydown', { key: 'Enter' });
+
+    expect(wrapper.emitted('submit')).toHaveLength(1);
+    wrapper.unmount();
+  });
+
+  test('输入其他按键时不提交搜索', async () => {
+    const wrapper = mount(SearchInput, {
+      global: {
+        stubs: {
+          HistoryCard: true,
+          RecommendCard: true,
+        },
+      },
+    });
+
+    await wrapper.find('input').trigger('keydown', { key: 'a' });
+
+    expect(wrapper.emitted('submit')).toBeUndefined();
+    wrapper.unmount();
+  });
+});

--- a/web/tests/unit/composables/useRouteState.spec.js
+++ b/web/tests/unit/composables/useRouteState.spec.js
@@ -1,0 +1,48 @@
+import { getRouteViewKey } from '@/app/composables/useRouteState';
+
+describe('getRouteViewKey', () => {
+  test('搜索关键词变化时更新结果页 key', () => {
+    const firstSearchKey = getRouteViewKey({
+      name: 'SearchPage',
+      params: {},
+      fullPath: '/search?type=all&query=first',
+    });
+    const secondSearchKey = getRouteViewKey({
+      name: 'SearchPage',
+      params: {},
+      fullPath: '/search?type=all&query=second',
+    });
+
+    expect(secondSearchKey).not.toBe(firstSearchKey);
+  });
+
+  test('调试模式下搜索关键词变化时同样更新结果页 key', () => {
+    const firstSearchKey = getRouteViewKey({
+      name: 'SearchPageDebug',
+      params: {},
+      fullPath: '/debug/search?type=all&query=first',
+    });
+    const secondSearchKey = getRouteViewKey({
+      name: 'SearchPageDebug',
+      params: {},
+      fullPath: '/debug/search?type=all&query=second',
+    });
+
+    expect(secondSearchKey).not.toBe(firstSearchKey);
+  });
+
+  test('其他页面仅修改查询参数时继续复用页面实例', () => {
+    const firstKey = getRouteViewKey({
+      name: 'SelfPage',
+      params: {},
+      fullPath: '/self?tab=profile',
+    });
+    const secondKey = getRouteViewKey({
+      name: 'SelfPage',
+      params: {},
+      fullPath: '/self?tab=notification',
+    });
+
+    expect(secondKey).toBe(firstKey);
+  });
+});


### PR DESCRIPTION
## 概述

修复搜索结果页在修改关键词后仍显示旧结果、必须手动刷新页面的问题，同时保留并增强 Enter 键触发搜索的行为。

## 改动内容

- 搜索路由参数变化时重新加载结果页，展示最新关键词对应的结果
- 同时支持桌面端、移动端及 Debug 路由
- 将 Enter 搜索改为组件级声明式提交，避免 DOM 绑定时序导致事件失效
- 移除旧的命令式键盘监听，防止重复触发
- 保持其他页面原有的路由组件复用行为
- 添加搜索路由刷新及 Enter 提交回归测试