### PR TITLE
fix: align search suggestions with input focus

### DIFF
--- a/web/src/AppMobile.vue
+++ b/web/src/AppMobile.vue
@@ -31,7 +31,7 @@
         :inputStyle="{ 'font-color': navIconColor, 'border-radius': '20px', height: '35px', width: '60vw', 'padding-left': '15px' }"></search-input>
       <!-- 搜索按钮 -->
       <div class="nav-btn-container">
-        <v-btn aria-label="搜索" @click="handleSpecialSearchClick" icon="mdi-magnify" variant="text" :color="navIconColor" size="35">
+        <v-btn aria-label="搜索" @mousedown.prevent @click="handleSpecialSearchClick" icon="mdi-magnify" variant="text" :color="navIconColor" size="35">
           <div class="icon-container">
             <v-icon type="mdi" icon="mdi-magnify" :color="navIconColor" size="25"></v-icon>
           </div>

--- a/web/src/components/common/searchInput/SearchInput.vue
+++ b/web/src/components/common/searchInput/SearchInput.vue
@@ -23,18 +23,11 @@
   </div>
 </template>
 <script>
-import { createEventBus } from '@/utils/eventBus';
 import HistoryCard from './utils/HistoryCard.vue';
 import RecommendCard from './utils/RecommendCard.vue';
 
 export default {
   emits: ['update:modelValue', 'blur', 'submit'],
-  setup() {
-    let eventBus = createEventBus("search-suggestion-show");
-    return {
-      eventBus
-    };
-  },
   data() {
     return {
       inputValue: this.modelValue,

--- a/web/src/components/common/searchInput/SearchInput.vue
+++ b/web/src/components/common/searchInput/SearchInput.vue
@@ -112,10 +112,10 @@ export default {
       }
     },
     submitSearch(event) {
+      this.$emit('submit');
       event.currentTarget.blur();
       this.isFocused = false;
       this.isSuggestionOpen = false;
-      this.$emit('submit');
     },
     fillSearchInput(text){
       this.inputValue=text;

--- a/web/src/components/common/searchInput/SearchInput.vue
+++ b/web/src/components/common/searchInput/SearchInput.vue
@@ -111,7 +111,9 @@ export default {
         this.isSuggestionOpen = true;
       }
     },
-    submitSearch() {
+    submitSearch(event) {
+      event.currentTarget.blur();
+      this.isFocused = false;
       this.isSuggestionOpen = false;
       this.$emit('submit');
     },

--- a/web/src/components/common/searchInput/SearchInput.vue
+++ b/web/src/components/common/searchInput/SearchInput.vue
@@ -12,11 +12,9 @@
       :placeholder="placeholderText"
     />
     <div
-      tabindex="0"
-      v-show="(isFocused || ifChildClicked)&&canSuggestion"
+      v-show="shouldShowSuggestions"
       class="suggestion-container"
-      @focus="onFocus"
-      @blur="onBlur"
+      @mousedown.prevent
     >
       <recommend-card @fill-search-input="fillSearchInput" v-show="showHot"></recommend-card>
       <div style="height: 80%; background-color: grey; width: 10px;"></div>
@@ -27,7 +25,6 @@
 <script>
 import { createEventBus } from '@/utils/eventBus';
 import HistoryCard from './utils/HistoryCard.vue';
-import { getLock, setLock } from '@/utils/lock';
 import RecommendCard from './utils/RecommendCard.vue';
 
 export default {
@@ -42,10 +39,9 @@ export default {
     return {
       inputValue: this.modelValue,
       isFocused: false, // 输入框是否获得焦点
+      isSuggestionOpen: false, // 是否显示搜索建议
       showHistory: true, // 是否显示历史记录
       showHot: true, // 是否显示热榜
-      ifChildClicked: false,
-      childClickIntervalId: null,
     };
   },
   props: {
@@ -95,6 +91,9 @@ export default {
     RecommendCard,
   },
   computed: {
+    shouldShowSuggestions() {
+      return this.canSuggestion && this.isFocused && this.isSuggestionOpen;
+    },
     // 动态生成 input 框的样式
     inputBoxStyle() {
       return Object.assign({},{
@@ -106,40 +105,26 @@ export default {
   methods: {
     onFocus() {
       this.isFocused = true;
+      this.isSuggestionOpen = true;
     },
-    async onBlur() {
-      setLock("search-suggestion-click-show", true);
-      let childState = await this.eventBus.waitFor('child-click', 200);
-      if (childState === true) {
-        this.ifChildClicked = true;
-        clearInterval(this.childClickIntervalId);
-        this.childClickIntervalId = setInterval(() => {
-          if (!getLock('search-suggestion-click-show')) {
-            this.ifChildClicked = false;
-          }
-        }, 3000)
-      }
-      setLock("search-suggestion-click-show", false);
+    onBlur() {
       //提交事件：搜索输入框失去焦点
       this.$emit('blur');
       this.isFocused = false;
+      this.isSuggestionOpen = false;
     },
     onInput() {
-      // 在这里监听当前输入的内容
+      if (this.isFocused) {
+        this.isSuggestionOpen = true;
+      }
     },
     submitSearch() {
+      this.isSuggestionOpen = false;
       this.$emit('submit');
     },
     fillSearchInput(text){
       this.inputValue=text;
     }
-  },
-  mounted() {
-    this.childClickIntervalId = setInterval(() => {
-      if (!getLock('search-suggestion-click-show')) {
-        this.ifChildClicked = false;
-      }
-    }, 3000)
   }
 };
 </script>

--- a/web/src/components/common/searchInput/utils/HistoryCard.vue
+++ b/web/src/components/common/searchInput/utils/HistoryCard.vue
@@ -1,5 +1,5 @@
 <template>
-    <div style="display: flex; flex-direction: column" class="total-container" :style="inputStyle" @click="globalClick">
+    <div style="display: flex; flex-direction: column" class="total-container" :style="inputStyle">
         <div style="display: flex;flex-direction: row;align-items: center;margin: 10px;">
             <div style="display: flex;flex-direction: row;align-items: center;width: 150px;">
                 <v-icon icon="mdi-clock-outline" size="20" style="margin-right: 3px;" color="grey"></v-icon>
@@ -20,7 +20,6 @@
     </div>
 </template>
 <script>
-import { globalProperties } from '@/main';
 import { deleteSearchHistory, getSearchHistory } from '../js/utils';
 import { createEventBus, getEventBus } from '@/utils/eventBus';
 import NothingView from '../../NothingView.vue';
@@ -33,14 +32,6 @@ export default {
             default:()=>{
                 return {};
             },
-        }
-    },
-    setup() {
-        const themeColor = globalProperties.$themeColor;
-        let eventBus=getEventBus("search-suggestion-show");
-        return {
-            themeColor,
-            eventBus
         }
     },
     components:{
@@ -76,9 +67,6 @@ export default {
             }else{
                 this.$emit("fill-search-input",item);
             }
-        },
-        globalClick(){
-            this.eventBus.emit('child-click',true);
         }
     }
 }

--- a/web/src/components/common/searchInput/utils/RecommendCard.vue
+++ b/web/src/components/common/searchInput/utils/RecommendCard.vue
@@ -1,5 +1,5 @@
 <template>
-    <div style="display: flex; flex-direction: column" class="total-container" :style="inputStyle" @click="globalClick">
+    <div style="display: flex; flex-direction: column" class="total-container" :style="inputStyle">
         <div style="display: flex;flex-direction: row;align-items: center;margin: 10px;">
             <div style="display: flex;flex-direction: row;align-items: center;width: 150px;">
                 <v-icon icon="mdi-fire" size="20" style="margin-right: 3px;" color="#ff3848"></v-icon>
@@ -23,7 +23,6 @@
     </div>
 </template>
 <script>
-import { globalProperties } from '@/main';
 import { reactive } from 'vue';
 import { createEventBus, getEventBus } from '@/utils/eventBus';
 import { getFireColor } from '../js/utils';
@@ -39,14 +38,10 @@ export default {
         }
     },
     setup() {
-        const themeColor = globalProperties.$themeColor;
         let items = reactive([
         ]);
-        let eventBus=getEventBus("search-suggestion-show");
         return {
-            themeColor,
             items,
-            eventBus
         }
     },
     components:{
@@ -57,9 +52,6 @@ export default {
         }
     },
     methods: {
-        globalClick(){
-            this.eventBus.emit('child-click',true);
-        },
         getFireColor(hotScore){
             return getFireColor(hotScore);
         },

--- a/web/tests/unit/components/SearchInput.spec.js
+++ b/web/tests/unit/components/SearchInput.spec.js
@@ -54,10 +54,13 @@ describe('SearchInput', () => {
   });
 
   test('提交搜索后失焦并在重新聚焦时显示建议', async () => {
+    const eventOrder = [];
     const wrapper = mount(SearchInput, {
       attachTo: document.body,
       props: {
         modelValue: '测试内容',
+        onSubmit: () => eventOrder.push('submit'),
+        onBlur: () => eventOrder.push('blur'),
       },
       global: {
         stubs: {
@@ -74,6 +77,7 @@ describe('SearchInput', () => {
     expect(document.activeElement).toBe(input.element);
 
     await input.trigger('keydown', { key: 'Enter' });
+    expect(eventOrder).toEqual(['submit', 'blur']);
     expect(document.activeElement).not.toBe(input.element);
     expect(suggestions.isVisible()).toBe(false);
 

--- a/web/tests/unit/components/SearchInput.spec.js
+++ b/web/tests/unit/components/SearchInput.spec.js
@@ -12,15 +12,6 @@ jest.mock('@/components/common/searchInput/utils/RecommendCard.vue', () => ({
 }));
 
 describe('SearchInput', () => {
-  beforeEach(() => {
-    jest.useFakeTimers();
-  });
-
-  afterEach(() => {
-    jest.clearAllTimers();
-    jest.useRealTimers();
-  });
-
   test('按 Enter 时只提交一次搜索', async () => {
     const wrapper = mount(SearchInput, {
       props: {
@@ -62,8 +53,9 @@ describe('SearchInput', () => {
     wrapper.unmount();
   });
 
-  test('提交搜索后隐藏建议并在继续输入时重新显示', async () => {
+  test('提交搜索后失焦并在重新聚焦时显示建议', async () => {
     const wrapper = mount(SearchInput, {
+      attachTo: document.body,
       props: {
         modelValue: '测试内容',
       },
@@ -77,11 +69,19 @@ describe('SearchInput', () => {
     const input = wrapper.find('input');
     const suggestions = wrapper.find('.suggestion-container');
 
-    await input.trigger('focus');
+    input.element.focus();
+    await wrapper.vm.$nextTick();
+    expect(document.activeElement).toBe(input.element);
+
     await input.trigger('keydown', { key: 'Enter' });
+    expect(document.activeElement).not.toBe(input.element);
     expect(suggestions.isVisible()).toBe(false);
 
     await input.setValue('新的内容');
+    expect(suggestions.isVisible()).toBe(false);
+
+    input.element.focus();
+    await wrapper.vm.$nextTick();
     expect(suggestions.isVisible()).toBe(true);
     wrapper.unmount();
   });

--- a/web/tests/unit/components/SearchInput.spec.js
+++ b/web/tests/unit/components/SearchInput.spec.js
@@ -40,6 +40,52 @@ describe('SearchInput', () => {
     wrapper.unmount();
   });
 
+  test('仅在搜索框聚焦时显示搜索建议', async () => {
+    const wrapper = mount(SearchInput, {
+      global: {
+        stubs: {
+          HistoryCard: true,
+          RecommendCard: true,
+        },
+      },
+    });
+    const input = wrapper.find('input');
+    const suggestions = wrapper.find('.suggestion-container');
+
+    expect(suggestions.isVisible()).toBe(false);
+
+    await input.trigger('focus');
+    expect(suggestions.isVisible()).toBe(true);
+
+    await input.trigger('blur');
+    expect(suggestions.isVisible()).toBe(false);
+    wrapper.unmount();
+  });
+
+  test('提交搜索后隐藏建议并在继续输入时重新显示', async () => {
+    const wrapper = mount(SearchInput, {
+      props: {
+        modelValue: '测试内容',
+      },
+      global: {
+        stubs: {
+          HistoryCard: true,
+          RecommendCard: true,
+        },
+      },
+    });
+    const input = wrapper.find('input');
+    const suggestions = wrapper.find('.suggestion-container');
+
+    await input.trigger('focus');
+    await input.trigger('keydown', { key: 'Enter' });
+    expect(suggestions.isVisible()).toBe(false);
+
+    await input.setValue('新的内容');
+    expect(suggestions.isVisible()).toBe(true);
+    wrapper.unmount();
+  });
+
   test('输入其他按键时不提交搜索', async () => {
     const wrapper = mount(SearchInput, {
       global: {


### PR DESCRIPTION
## Summary

- Show hot searches and search history only while the search input is active.
- Hide suggestions on blur and blur the input after submission.
- Remove obsolete event-bus, lock, and polling logic.
- Preserve search-button behavior on mobile detail pages.